### PR TITLE
fix: NEXT_PUBLIC_API_URL pointe vers api:3001

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       context: ./web
       dockerfile: Dockerfile
       args:
-        - NEXT_PUBLIC_API_URL=http://localhost:3001/api
+        - NEXT_PUBLIC_API_URL=http://api:3001/api
     container_name: terrangafood-web
     ports:
       - "3000:3000"


### PR DESCRIPTION
test: rapport tests Docker Lab 3  Closes #36 